### PR TITLE
feat(auth): add AboutUs section to login page (v1.1.0)

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import LoginForm from './features/auth/component/LoginForm.js';
-
+import LoginForm from './features/auth/component/LoginForm';
+import AboutUs from './features/auth/component/AboutUs'; // import AboutUs component
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<LoginForm />} />
+        <Route path="/AboutUs" element={<AboutUs />} /> {/* new route for About Us */}
       </Routes>
     </Router>
   );

--- a/web/src/features/auth/component/AboutUs.css
+++ b/web/src/features/auth/component/AboutUs.css
@@ -1,0 +1,122 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,900&display=swap');
+
+        /* Reset and Base Styles */
+        * {
+          box-sizing: border-box;
+          margin: 0;
+          padding: 0;
+        }
+
+        .about-us-container {
+          font-family: 'Roboto', sans-serif; /* close match to the clean sans-serif used */
+          width: 100%;
+          min-height: 100vh;
+          display: flex;
+          flex-direction: column;
+        }
+
+        /* Header Section */
+        header {
+          background-color: rgb(255, 255, 255);
+          padding: 20px 40px;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          /* Optional: Add a subtle shadow or border if desired, though image looks clean */
+        }
+
+        .logo {
+        font-family: 'Fugaz One', sans-serif;
+        font-size: 32px;
+        font-weight: 900; /* Extra bold */
+        font-style: italic;
+        color: #0B1C30; /* Dark Navy Blue extracted from image */
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+        }
+
+
+        .login-btn {
+          background: transparent;
+          border: 2px solid #333;
+          padding: 8px 30px;
+          border-radius: 20px; /* Rounded pill shape */
+          font-size: 14px;
+          font-weight: 500;
+          cursor: pointer;
+          color: #333;
+          transition: all 0.3s ease;
+        }
+
+        .login-btn:hover {
+          background-color: #99cf66;
+        }
+
+        /* Main Content Section */
+        .main-content {
+          /* Replace # with your real image path */
+          background-image: url('D:/y3-s1/csci-313 (software)/Git/Project/AL-FARES/features/auth/auth/frontend/src/assets/aboutUsBG.png'); 
+          background-size: cover;
+          background-position: center;
+          background-repeat: no-repeat;
+          flex: 1; /* Takes up remaining height */
+          display: flex;
+          flex-direction: column;
+          justify-content: center; /* Vertically centers the content block */
+          padding-left: 8%; /* Indentation from the left */
+          padding-right: 20px;
+          color: rgb(231, 231, 231);
+          position: relative;
+        }
+
+        /* Dark overlay to ensure text readability if the image is too bright 
+           (The reference image is naturally dark, but this helps) */
+        .main-content::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background: rgba(0, 0, 0, 0.5); /* Adjust opacity as needed */
+          z-index: 1;
+        }
+
+        /* Wrapper to lift text above the overlay */
+        .content-wrapper {
+          position: relative;
+          z-index: 2;
+          max-width: 900px; /* Limits width to match the visual reference */
+        }
+
+        h1 {
+          font-size: 48px;
+          font-weight: 400; /* Regular weight, not bold */
+          margin-bottom: 75px;
+        }
+
+        p {
+          font-size: 20px;
+          line-height: 1.5;
+          margin-bottom: 5px; /* Minimal space between paragraphs to look like one block */
+        }
+        
+        /* Mobile Responsiveness */
+        @media (max-width: 768px) {
+          header {
+            padding: 15px 20px;
+          }
+          
+          .main-content {
+            padding-left: 20px;
+            padding-right: 20px;
+          }
+
+          h1 {
+            font-size: 32px;
+          }
+
+          p {
+            font-size: 16px;
+          }
+        }

--- a/web/src/features/auth/component/AboutUs.js
+++ b/web/src/features/auth/component/AboutUs.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import './AboutUs.css';
+import { Link } from 'react-router-dom';
+
+const AboutUs = () => {
+  return (
+    <div className="about-us-container">
+      <header>
+        <div className="logo">AL FARES</div>
+
+      <Link to="/">
+        <button className="login-btn">LOGIN</button>
+      </Link>
+      </header>
+
+      <main className="main-content">
+        <div className="content-wrapper">
+          <h1>Who we are?</h1>
+          <p>
+            AL FARES is your one-stop online store for all school and university supplies.
+            From notebooks and pens to backpacks and study essentials, we provide everything students need.
+          </p>
+          <p>
+            What sets us apart? We are <strong>available 24/7</strong> to serve our customers, ensuring you can order anytime and get your supplies quickly and reliably.
+          </p>
+          <p>
+            Our mission is to make shopping for educational supplies easy, convenient, and fast, so you can focus on what really matters – your studies.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default AboutUs;


### PR DESCRIPTION
Added the AboutUs section to the login page as a new feature.
This is a backward-compatible addition; further improvements may follow.
Bumped version from v1.0.0 → v1.1.0.

<img width="534" height="500" alt="image" src="https://github.com/user-attachments/assets/44d41879-297b-4c92-95cd-47d86d2a0a15" />
<img width="1303" height="600" alt="image" src="https://github.com/user-attachments/assets/54bf2042-49ce-4f31-a355-7c9cd53271fa" />
